### PR TITLE
Feature excepted http response code

### DIFF
--- a/src/Rygilles/OpenApiGenerator/Generators/Generator.php
+++ b/src/Rygilles/OpenApiGenerator/Generators/Generator.php
@@ -394,6 +394,9 @@ abstract class Generator
 					
 					case 'put':
 					case 'patch':
+						$operation->responses['200'] = $response;
+						break;
+						
 					case 'post':
 						$operation->responses['201'] = $response;
 						break;

--- a/src/Rygilles/OpenApiGenerator/Generators/Generator.php
+++ b/src/Rygilles/OpenApiGenerator/Generators/Generator.php
@@ -373,23 +373,35 @@ abstract class Generator
 			if (!is_null($responseMediaType)) {
 				$response->content['application/json'] = $responseMediaType;
 			}
+			
+			// Excepted HTTP code specified ? "OpenApiResponseExceptedHTTPCode" tag
+			
+			$apiResponseExceptedHTTPCode = null;
+			$apiResponseExceptedHTTPCodeTags = $routeMethodDocBlock->getTagsByName('OpenApiResponseExceptedHTTPCode');
+			if (count($apiResponseExceptedHTTPCodeTags) > 0) {
+				$apiResponseExceptedHTTPCodeTag = $apiResponseExceptedHTTPCodeTags[0];
+				$apiResponseExceptedHTTPCode = trim(str_replace('@OpenApiResponseExceptedHTTPCode', '', $apiResponseExceptedHTTPCodeTag->render()));
+			}
 
-			switch (strtolower($httpMethod)) {
-				// @todo different HTTP code ?
-				case 'get':
-				//case 'head':
-					$operation->responses['200'] = $response;
-					break;
-
-				case 'put':
-				case 'patch':
-				case 'post':
-					$operation->responses['201'] = $response;
-					break;
-
-				case 'delete':
-					$operation->responses['204'] = $response;
-					break;
+			if (!is_null($apiResponseExceptedHTTPCode)) {
+				$operation->responses[$apiResponseExceptedHTTPCode] = $response;
+			} else {
+				switch (strtolower($httpMethod)) {
+					case 'get':
+						//case 'head':
+						$operation->responses['200'] = $response;
+						break;
+					
+					case 'put':
+					case 'patch':
+					case 'post':
+						$operation->responses['201'] = $response;
+						break;
+					
+					case 'delete':
+						$operation->responses['204'] = $response;
+						break;
+				}
 			}
 
 			// Default response (Errors)


### PR DESCRIPTION
A new phpdoc tag "OpenApiResponseExceptedHTTPCode" allows you tu specify the excepted response ode now.

FIx : Default behavior for excepted HTTP response code update :
200 for PUT and PATCH HTTP methods (not 201 !)

Fixes #2 